### PR TITLE
Storage class migration

### DIFF
--- a/terraform/buckets.tf
+++ b/terraform/buckets.tf
@@ -1,7 +1,19 @@
 resource "google_storage_bucket" "backup-bucket" {
   name          = "backup-bucket-${var.project_id}"
   location      = "NORTHAMERICA-NORTHEAST2"
-  force_destroy = true
+  force_destroy = false
 
   public_access_prevention = "enforced"
+
+  storage_class = "ARCHIVE"
+
+  lifecycle_rule {
+    action {
+      type = "SetStorageClass"
+      storage_class = "ARCHIVE"
+    }
+    condition {
+      matches_storage_class = ["STANDARD", "NEARLINE", "COLDLINE"]
+    }
+  }
 }

--- a/terraform/buckets.tf
+++ b/terraform/buckets.tf
@@ -9,7 +9,7 @@ resource "google_storage_bucket" "backup-bucket" {
 
   lifecycle_rule {
     action {
-      type = "SetStorageClass"
+      type          = "SetStorageClass"
       storage_class = "ARCHIVE"
     }
     condition {

--- a/terraform/buckets.tf
+++ b/terraform/buckets.tf
@@ -5,16 +5,16 @@ resource "google_storage_bucket" "backup-bucket" {
 
   public_access_prevention = "enforced"
 
-  storage_class = "ARCHIVE"
+  storage_class = "COLDLINE"
 
   lifecycle_rule {
     action {
       type          = "SetStorageClass"
-      storage_class = "ARCHIVE"
+      storage_class = "COLDLINE"
     }
     condition {
-      matches_storage_class = ["STANDARD", "NEARLINE", "COLDLINE"]
-      age = 0
+      matches_storage_class = ["STANDARD", "NEARLINE", "ARCHIVE"]
+      age                   = 0
     }
   }
 }

--- a/terraform/buckets.tf
+++ b/terraform/buckets.tf
@@ -14,6 +14,7 @@ resource "google_storage_bucket" "backup-bucket" {
     }
     condition {
       matches_storage_class = ["STANDARD", "NEARLINE", "COLDLINE"]
+      age = 0
     }
   }
 }


### PR DESCRIPTION
This pull request updates the configuration for the `backup-bucket` Google Cloud Storage bucket to enhance data retention and cost optimization. The most important changes are grouped below:

**Bucket retention and lifecycle management:**

* Changed `force_destroy` from `true` to `false` to prevent accidental deletion of the `backup-bucket` and its contents.
* Set the default `storage_class` to `ARCHIVE` to reduce storage costs for long-term backups.
* Added a `lifecycle_rule` to automatically transition objects from `STANDARD`, `NEARLINE`, or `COLDLINE` storage classes to `ARCHIVE`, ensuring all objects are stored in the most cost-effective class for backups.